### PR TITLE
add isInferred field

### DIFF
--- a/src/main/scala/com/gu/rcspollerlambda/models/RCS.scala
+++ b/src/main/scala/com/gu/rcspollerlambda/models/RCS.scala
@@ -92,7 +92,7 @@ object RCSUpdate {
   implicit val encoder: Encoder[RCSUpdate] = deriveEncoder[RCSUpdate]
 }
 
-case class SyndicationRights(published: Option[DateTime], suppliers: Seq[Supplier], rights: Seq[Right])
+case class SyndicationRights(published: Option[DateTime], suppliers: Seq[Supplier], rights: Seq[Right], isInferred: Boolean = false)
 object SyndicationRights {
   import DateTimeFormatter._
   implicit val encoder: Encoder[SyndicationRights] = deriveEncoder[SyndicationRights]


### PR DESCRIPTION
defaulted to `false`, `isInferred` signifies that the rights came from rcs

see https://github.com/guardian/grid/pull/2299 for more info