### PR TITLE
Increase timeout

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -38,7 +38,7 @@ Mappings:
     CODE:
       Rate: rate(10 minutes)
     PROD:
-      Rate: rate(1 hour)
+      Rate: rate(30 minutes)
 
 Resources:
   LambdaSecurityGroup:
@@ -137,7 +137,7 @@ Resources:
       MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 300
+      Timeout: 900
 
   RateEvent:
     Type: AWS::Events::Rule

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -38,7 +38,7 @@ Mappings:
     CODE:
       Rate: rate(10 minutes)
     PROD:
-      Rate: rate(30 minutes)
+      Rate: rate(1 hour)
 
 Resources:
   LambdaSecurityGroup:

--- a/src/main/scala/com/gu/rcspollerlambda/services/HTTP.scala
+++ b/src/main/scala/com/gu/rcspollerlambda/services/HTTP.scala
@@ -27,7 +27,7 @@ object HTTP extends Config {
           case 200 => Right(result.body)
           case _ => Left(RCSError(result.body))
         }
-      }, 4.minutes)
+      }, 10.minutes)
     } catch {
       case e: Throwable =>
         wsClient.close()


### PR DESCRIPTION
Sometimes RCS takes a long time to do their query and our lambda fails. This tries to fix it by allowing the lambda to run for longer.