### PR TITLE
Run PROD lambda every 10 minutes rather than once an hour. Improves i…

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -38,7 +38,7 @@ Mappings:
     CODE:
       Rate: rate(10 minutes)
     PROD:
-      Rate: rate(1 hour)
+      Rate: rate(10 minutes)
 
 Resources:
   LambdaSecurityGroup:


### PR DESCRIPTION
…nteractivity and reduces our exposure to huge change sets which may take RCS along time to generate