### PR TITLE
Increase alarm threshold to 2 hours

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -189,7 +189,7 @@ Resources:
       Statistic: Sum
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
-      Period: '300'
+      Period: '600'
       EvaluationPeriods: 12
       AlarmActions:
       - !Ref AlarmTopic


### PR DESCRIPTION
Trello card: https://trello.com/c/NA5CgRw5

This change will ensure the alarm will only trigger after 12 concurrent 10-minute lambda failures, totalling 2 hours of failures.

In the past, this alarm would fire every morning due to a regular issue happening for under two hours around 4:14am. This change will ensure that doesn't set off the alarm while we investigate the root cause.