### PR TITLE
Remediate CVE-2021-44228

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
   "com.gu" %% "scanamo" % "1.0.0-M6",
   "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.2",
   "io.circe" %% "circe-core" % circeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
-  "org.slf4j" % "slf4j-log4j12" % "1.7.25",
+  "org.slf4j" % "slf4j-simple" % "1.7.32",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "org.mockito" % "mockito-core" % "2.18.0" % Test
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.5.7

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -4,6 +4,6 @@ log4j.rootLogger=INFO,LAMBDA
 log4j.logger.io.netty=WARN,LAMBDA
 
 #Define the LAMBDA appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA=org.apache.log4j.ConsoleAppender
 log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
 log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} <%X{AWSRequestId}> %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

- Bump the version of SBT
- Removes the `aws-lambda-java-log4j` dependency as it's not needed
- Replace `slf4j-log4j12` with `slf4j-simple` as `slf4j-log4j12` brings in a vulnerable (CVE-2021-44228) transitive dependency log4j.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy to CODE
- Observe logs appearing