### PR TITLE
Upgrade play-ws to resolve critical vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.gu" %% "scanamo" % "1.0.0-M6",
-  "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.1.2",
+  "com.typesafe.play" %% "play-ahc-ws-standalone" % "2.1.10",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/src/main/scala/com/gu/rcspollerlambda/Lambda.scala
+++ b/src/main/scala/com/gu/rcspollerlambda/Lambda.scala
@@ -1,7 +1,7 @@
 package com.gu.rcspollerlambda
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.rcspollerlambda.models.{ LambdaError, RightsBatch }
 import com.gu.rcspollerlambda.services._
@@ -13,7 +13,6 @@ object Lambda extends Logging {
   system.registerOnTermination {
     System.exit(0)
   }
-  implicit private val materializer: ActorMaterializer = ActorMaterializer()
 
   /*
    * This is the lambda entry point


### PR DESCRIPTION
## What does this change?

Upgrade play-ahc-ws-standalone to get an updated version of Akka, to resolve critical vulnerability for project
